### PR TITLE
Add tests for customer

### DIFF
--- a/JWT/jwt-signature-apis-challenges/app.js
+++ b/JWT/jwt-signature-apis-challenges/app.js
@@ -29,9 +29,9 @@ app.post('/jwt/none', (req, res) => { //None endpoint
     if (jwt_b64_dec.header.alg == 'HS256') {
       secret_key = '885ae2060fbedcfb491c5e8aafc92cab5a8057b3d4c39655acce9d4f09280a20';
     } else if (jwt_b64_dec.header.alg == 'none') {
-      secret_key = '';
+      res.status(400).send('JWT Token not valid');
     }
-    JWT.verify(jwt_token, secret_key, { algorithms: ['none', 'HS256'], complete: true, audience: 'https://127.0.0.1/jwt/none' }, (err, decoded_token) => {
+    JWT.verify(jwt_token, secret_key, { algorithms: ['HS256'], complete: true, audience: 'https://127.0.0.1/jwt/none' }, (err, decoded_token) => {
       if (err) {
         res.status(400).json(err);
       } else {

--- a/Python/Flask_Book_Library/Dockerfile
+++ b/Python/Flask_Book_Library/Dockerfile
@@ -11,6 +11,7 @@ ENV PASSWORD=1qaz@WSX
 # Instalujemy zależności
 RUN pip install --no-cache-dir -r requirements.txt
 
+RUN pytest
 # Ustawiamy zmienną środowiskową, aby Flask wiedział, jak uruchomić aplikację
 ENV FLASK_APP=app.py
 ENV FLASK_RUN_HOST=0.0.0.0

--- a/Python/Flask_Book_Library/project/tests/customer_tests.py
+++ b/Python/Flask_Book_Library/project/tests/customer_tests.py
@@ -1,0 +1,83 @@
+import pytest
+from project.customers.models import Customer
+
+
+@pytest.mark.parametrize("name, city, age, pesel, street, appNo", [
+    ("Jan Kowalski", "Warszawa", 25, "82020512345", "Marszałkowska", "12A"),
+    ("Anna Nowak", "Kraków", 30, "91030623456", "Floriańska", "45"),
+    ("Piotr Wiśniewski", "Wrocław", 45, "76090734567", "Świdnicka", "8"),
+    ("Maria Wójcik", "Poznań", 19, "03292845678", "Wielka", "15"),
+    ("Tomasz Kowalczyk", "Gdańsk", 35, "87121956789", "Długa", "3/4"),
+    ("Katarzyna Kamińska", "Łódź", 28, "94052067890", "Piotrkowska", "100"),
+    ("Michał Lewandowski", "Szczecin", 42, "79081178901", "Wojska Polskiego", "22B"),
+    ("Magdalena Zielińska", "Lublin", 33, "88111289012", "Krakowskie Przedmieście", "9"),
+    ("Krzysztof Szymański", "Katowice", 51, "71040199123", "Mariacka", "7"),
+    ("Agnieszka Woźniak", "Białystok", 29, "93072100234", "Lipowa", "16/5")
+])
+def test_valid_customer_data(name, city, age, pesel, street, appNo):
+    customer = Customer(
+        name=name,
+        city=city,
+        age=age,
+        pesel=pesel,
+        street=street,
+        appNo=appNo
+    )
+
+    assert customer.name == name
+    assert customer.city == city
+    assert customer.age == age
+    assert customer.pesel == pesel
+    assert customer.street == street
+    assert customer.appNo == appNo
+
+@pytest.mark.parametrize("name, city, age, pesel, street, appNo", [
+    (20, "Warszawa", 25, 82020512345, "Marszałkowska", "12A"),
+    ("Anna Nowak", "Kraków", 30, 2, "Floriańska", 45),
+    ("Piotr Wiśniewski", 2, 45, "76090734567", "Świdnicka", "8"),
+    ("Maria Wójcik", "Poznań", "Dwa", "03292845678", "Wielka", "15"),
+    (None, "Gdańsk", 35, "87121956789", "Długa", 3.5),
+    ("Krzysztof Szymański", None, 51, "71040199123", "Mariacka", None),
+])
+def test_wrong_data_format(name, city, age, pesel, street, appNo):
+    with pytest.raises(Exception):
+        customer = Customer(
+            name=name,
+            city=city,
+            age=age,
+            pesel=pesel,
+            street=street,
+            appNo=appNo
+        )
+
+
+@pytest.mark.parametrize("sqli_payload", [
+    "1' OR '1'='1",
+    "' OR '1'='1' --",
+    "1; DROP TABLE books; --",
+    "'; SELECT * FROM users WHERE '1'='1",
+    "1' UNION SELECT null, null, null, null, null; --",
+    "' OR 'a'='a",
+])
+@pytest.mark.parametrize("field", ["name", "city", "age", "pesel", "street", "appNo"])
+def test_sqli_data_format(sqli_payload, field):
+    with pytest.raises(Exception):
+        valid_customer_data = {"name": "Jan Kowalski", "city": "Warszawa", "age": 25, "pesel": "82020512345",
+                               "street": "Marszałkowska", "appNo": "12A", field: sqli_payload}
+
+        with pytest.raises(Exception):
+            customer = Customer(**valid_customer_data)
+
+
+@pytest.mark.parametrize("variable_length", [
+    1000,
+    10000
+])
+@pytest.mark.parametrize("field", ["name", "city", "pesel", "street", "appNo"])
+def test_sqli_data_format(variable_length, field):
+    with pytest.raises(Exception):
+        valid_customer_data = {"name": "Jan Kowalski", "city": "Warszawa", "age": 25, "pesel": "82020512345",
+                               "street": "Marszałkowska", "appNo": "12A", field: 'X' * variable_length}
+
+        with pytest.raises(Exception):
+            customer = Customer(**valid_customer_data)

--- a/Python/Flask_Book_Library/requirements.txt
+++ b/Python/Flask_Book_Library/requirements.txt
@@ -15,3 +15,4 @@ SQLAlchemy==2.0.21
 typing_extensions==4.8.0
 Werkzeug==2.3.7
 WTForms==3.0.1
+pytest==8.3.4


### PR DESCRIPTION
## Zad2
W zadaniu drugim wykorzystana została podatność polegająca na ustawieniu algorytmu podpisywania tokenu na None. Dzięki temu mogłem ustawić własny payload i ominąć sprawdzenie podpisu tokenu JWT.
<img width="809" alt="Screenshot 2024-12-09 at 16 57 05" src="https://github.com/user-attachments/assets/230321c6-89fb-409e-b7f7-e1ed2519ae3b">
