### PR TITLE
Jacek Strzałkowski Zadanie 03

### DIFF
--- a/JWT/jwt-signature-apis-challenges/app.js
+++ b/JWT/jwt-signature-apis-challenges/app.js
@@ -31,7 +31,7 @@ app.post('/jwt/none', (req, res) => { //None endpoint
     } else if (jwt_b64_dec.header.alg == 'none') {
       secret_key = '';
     }
-    JWT.verify(jwt_token, secret_key, { algorithms: ['none', 'HS256'], complete: true, audience: 'https://127.0.0.1/jwt/none' }, (err, decoded_token) => {
+    JWT.verify(jwt_token, secret_key, { algorithms: ['HS256'], complete: true, audience: 'https://127.0.0.1/jwt/none' }, (err, decoded_token) => {
       if (err) {
         res.status(400).json(err);
       } else {

--- a/Python/Flask_Book_Library/Dockerfile
+++ b/Python/Flask_Book_Library/Dockerfile
@@ -11,6 +11,9 @@ ENV PASSWORD=1qaz@WSX
 # Instalujemy zależności
 RUN pip install --no-cache-dir -r requirements.txt
 
+# Unittest
+RUN python -m unittest tests/books_test.py
+
 # Ustawiamy zmienną środowiskową, aby Flask wiedział, jak uruchomić aplikację
 ENV FLASK_APP=app.py
 ENV FLASK_RUN_HOST=0.0.0.0

--- a/Python/Flask_Book_Library/tests/books_test.py
+++ b/Python/Flask_Book_Library/tests/books_test.py
@@ -1,0 +1,104 @@
+import unittest
+from project import db
+from project.books.models import Book
+
+
+# Testy poprawnych danych
+# Testy niepoprawnych danych
+# Testy związane z próbą wstrzyknięcia kodu SQL i kodu JavaScript
+# Testy ekstremalne
+
+
+class BookModelTestCase(unittest.TestCase):
+
+    # test poprawnych danych
+
+    correct_inputs = {
+        "name": "Test Book",
+        "author": "Test Author",
+        "year_published": 2021,
+        "book_type": "Fiction",
+    }
+
+    def test_book_creation(self):
+
+        book = Book(**self.correct_inputs)
+
+        self.assertEqual(book.name, "Test Book")
+        self.assertEqual(book.author, "Test Author")
+        self.assertEqual(book.year_published, 2021)
+        self.assertEqual(book.book_type, "Fiction")
+
+    # test niepoprawnych danych
+
+    incorrect_inputs = {
+        "name": "77771112331131#$",
+        "author": "77771112331131#$",
+        "year_published": "NOTAYEAR",
+        "book_type": "163874",
+    }
+
+    def test_book_creation_incorrect_data(self):
+        for incorect_input in self.incorrect_inputs:
+            input = self.correct_inputs.copy()
+            input.update({incorect_input: self.incorrect_inputs[incorect_input]})
+            with self.assertRaises(ValueError):
+                book = Book(**input)
+
+    # testy wstrzyknięcia kodu SQL i JavaScript
+
+    sql_injection = {
+        "name": "Test Book'; DROP TABLE books; --",
+        "author": "Test Author'; DROP TABLE books; --",
+        "year_published": 2021,
+        "book_type": "Fiction",
+    }
+
+    js_injection = {
+        "name": "Test Book<script>alert('XSS')</script>",
+        "author": "Test Author<script>alert('XSS')</script>",
+        "year_published": 2021,
+        "book_type": "Fiction",
+    }
+
+    def test_sql_injection(self):
+        for incorect_input in self.sql_injection:
+            input = self.correct_inputs.copy()
+            input.update({incorect_input: self.sql_injection[incorect_input]})
+            with self.assertRaises(ValueError):
+                book = Book(**input)
+
+    def test_js_injection(self):
+        for incorect_input in self.js_injection:
+            input = self.correct_inputs.copy()
+            input.update({incorect_input: self.js_injection[incorect_input]})
+            with self.assertRaises(ValueError):
+                book = Book(**input)
+
+    # testy ekstremalne
+    def test_book_creation_empty(self):
+        with self.assertRaises(ValueError):
+            book = Book()
+
+        with self.assertRaises(ValueError):
+            empty_inputs = self.correct_inputs.copy()
+            empty_inputs.update({"name": ""})
+            book = Book(**empty_inputs)
+
+    big_input = {
+        "name": "X" * 10_000,
+        "author": "X" * 10_000,
+        "year_published": 1_000_000_000_000_000_000,
+        "book_type": "X" * 10_000,
+    }
+
+    def test_big_data(self):
+        for incorect_input in self.big_input:
+            input = self.correct_inputs.copy()
+            input.update({incorect_input: self.big_input[incorect_input]})
+            with self.assertRaises(ValueError):
+                book = Book(**input)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Zadanie 1

Dodano testy jednostkowe dla klasy `Book`. Dodano sprawdzenie do `Dockerfile` pomyślności przejścia testów

```sh
# Unittest
RUN python -m unittest tests/books_test.py
```

Powyższy test musi być wykonany po instalacji bibliotek za pomocą `pip install -r requirements.txt`.

## Zadanie 2

Uzyskany token dla użytkownika `Bob`.

```json
{
    "jwt_token":"eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.eyJhY2NvdW50IjoiQWRtaW5pc3RyYXRvciIsInJvbGUiOiJVc2VyIiwiaWF0IjoxNzAxNzIyODU2LCJhdWQiOiJodHRwczovLzEyNy4wLjAuMS9qd3Qvbm9uZSJ9."
}
```

Wysyłany token na `jwt/none` składa się z trzech części: nagłówka, ładunku i podpisu. Podpis uzyskiwany jest poprzez szyfrowanie z sekretem hardkodowanym w pliku źródłowym aplikacji.

Można zauważyć, że kodując nagłówek precyzujący, żeby nie stosować metody podpisu

```json
{"alg":"none"}
```

możemy użyć ładunku związanego z innym użytkownikiem, np.

```json
{"alg":"none"}
.
{
    "account":"Administrator",
    "role":"User",
    "iat":1701722856,
    "aud":"https://127.0.0.1/jwt/none"
}
```

co po zakodowaniu `base64` i dodaniu `.` przedstawia się następująco

```
eyJhbGciOiJub25lIn0K.eyJhY2NvdW50IjoiQWRtaW5pc3RyYXRvciIsInJvbGUiOiJVc2VyIiwiaWF0IjoxNzAxNzIyODU2LCJhdWQiOiJodHRwczovLzEyNy4wLjAuMS9qd3Qvbm9uZSJ9.
```

`0K` bądź `0=` to znaki wyrównujące i można je ominąć kodując na potrzeby zapytań HTTP.

Po wyslaniu POSTa na `jwt/none` z powyższym ciałem uzyskujemy odpowiedź

![admin_priv](https://github.com/user-attachments/assets/d13e9331-e0e5-4e07-a3ee-bc841e0a861c)

### Usunięcie podatności

Usunięcie podatności może zostać zrealizowane poprzez usunięcie możliwości wysłania niepodpisanego posta.

Wówczas powyższy `POST` przestaje być problem - przy takim zapytaniu zwracana jest informacja o niewłaściwym algorytmie.

![after_fix](https://github.com/user-attachments/assets/bec64ddb-c2e1-4781-85cf-c04f74e7306f)
