### PR TITLE
MD - TBO Lab 3

### DIFF
--- a/JWT/jwt-signature-apis-challenges/app.js
+++ b/JWT/jwt-signature-apis-challenges/app.js
@@ -28,10 +28,8 @@ app.post('/jwt/none', (req, res) => { //None endpoint
     const jwt_b64_dec = JWT.decode(jwt_token, { complete: true });
     if (jwt_b64_dec.header.alg == 'HS256') {
       secret_key = '885ae2060fbedcfb491c5e8aafc92cab5a8057b3d4c39655acce9d4f09280a20';
-    } else if (jwt_b64_dec.header.alg == 'none') {
-      secret_key = '';
     }
-    JWT.verify(jwt_token, secret_key, { algorithms: ['none', 'HS256'], complete: true, audience: 'https://127.0.0.1/jwt/none' }, (err, decoded_token) => {
+    JWT.verify(jwt_token, secret_key, { algorithms: ['HS256'], complete: true, audience: 'https://127.0.0.1/jwt/none' }, (err, decoded_token) => {
       if (err) {
         res.status(400).json(err);
       } else {

--- a/Java/spring-thymeleaf-crud-example/Dockerfile
+++ b/Java/spring-thymeleaf-crud-example/Dockerfile
@@ -10,7 +10,7 @@ COPY src /app/src
 COPY pom.xml /app
 
 # Package the application
-RUN mvn clean install -DskipTests
+RUN mvn clean install
 
 # ---- Deploy Stage ----
 FROM openjdk:11-jdk-slim

--- a/Java/spring-thymeleaf-crud-example/src/test/java/com/example/thymeleaf/entity/TBOTests.java
+++ b/Java/spring-thymeleaf-crud-example/src/test/java/com/example/thymeleaf/entity/TBOTests.java
@@ -1,0 +1,94 @@
+package com.example.thymeleaf.entity;
+
+import org.junit.jupiter.api.Test;
+
+import com.example.thymeleaf.dto.CreateStudentDTO;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.LocalDate;
+import java.util.Set;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.Validation;
+import javax.validation.Validator;
+
+class TBOTests {
+
+    @Test
+    void StudentDTOTestCorrect() {
+        Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+
+        //CreateStudentDTO is the only class with constraints so it should be the one to be tested for input validation
+        CreateStudentDTO dto = SetupStudentDTO("Andrew", "andrew@gmail.com", LocalDate.of(2000, 10, 2), "0000000",
+                                        "Street", "5", "some compliment", "Joshua", "Boston", "Alaska");
+
+        Set<ConstraintViolation<CreateStudentDTO>> violations = validator.validate(dto);
+        assertTrue(violations.size() == 0);
+    }
+
+    @Test
+    void StudentDTOTestIncorrect() {
+        Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+
+        //missing/null data
+        CreateStudentDTO dto = SetupStudentDTO("", "", LocalDate.of(2000, 10, 2), "",
+                                        "", "", "", "", "", "");
+
+        Set<ConstraintViolation<CreateStudentDTO>> violations = validator.validate(dto);
+        assertTrue(violations.size() == 8);//-1 because complement can be empty
+
+        //incorrect data examples
+        CreateStudentDTO dto2 = SetupStudentDTO("({}*&79})", "({}*&79})@gmail.com", LocalDate.of(3024, 10, 2), "asdjygsdif",
+                                        "({}*&79})", "adyfasghab", "({}*&79})<!/>", "({}*&79})", "({}*&79})", "({}*&79})");
+
+        Set<ConstraintViolation<CreateStudentDTO>> violations2 = validator.validate(dto2);
+        assertTrue(violations2.size() == 10);
+    }
+
+    @Test
+    void StudentDTOTestInjection() {
+        Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+
+        String injectionStr = "<script>alert('XSS');</script>";
+
+        CreateStudentDTO dto = SetupStudentDTO(injectionStr, injectionStr, LocalDate.of(2000, 10, 2), injectionStr,
+                                            injectionStr, injectionStr, injectionStr, injectionStr, injectionStr, injectionStr);
+
+        Set<ConstraintViolation<CreateStudentDTO>> violations = validator.validate(dto);
+        assertTrue(violations.size() == 9);
+    }
+
+    @Test
+    void StudentDTOTestExtreme() {
+        Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+
+        String bigString = "x".repeat(10000);
+
+        CreateStudentDTO dto = SetupStudentDTO(bigString, bigString, LocalDate.of(2000, 10, 2), bigString,
+                                            bigString, bigString, bigString, bigString, bigString, bigString);
+
+        Set<ConstraintViolation<CreateStudentDTO>> violations = validator.validate(dto);
+        assertTrue(violations.size() == 9);
+    }
+
+    //helper functions
+
+    CreateStudentDTO SetupStudentDTO(String name, String email, LocalDate birthday, String ZipCode, String street, String number, String complement, 
+                                      String district, String city, String state) {
+
+        CreateStudentDTO dto = new CreateStudentDTO();
+        dto.setName(name);
+        dto.setEmail(email);
+        dto.setBirthday(birthday);
+        dto.setZipCode(ZipCode);
+        dto.setStreet(street);
+        dto.setNumber(number);
+        dto.setComplement(complement);
+        dto.setDistrict(district);
+        dto.setCity(city);
+        dto.setState(state);
+
+        return dto;
+    }
+}


### PR DESCRIPTION
# Zad 1

Stworzone zostały testy jednostkowe mające na celu sprawdzić poprawność akceptowania danych od użytkownika przez aplikację.
Testy zostały wykonane na klasie "CreateStudentDTO" gdyż jest ona odpowiedzialna w tej aplikacji za przekazywanie danych do klas entity oraz za sprawdzanie ich poprawności. (klasy definiujące właściwe entity nie mają żadnej walidacji, choć powinny mieć)
Ze stworzonych testów pomyślnie zakończył się tylko jeden, więc w tej aplikacji jest trochę do poprawienia.
![0-testy jednostkowe](https://github.com/user-attachments/assets/5ce116db-e0eb-469c-813c-32c7933020b4)

# Zad 2

### Wstęp

Na początku przy użyciu requesta "none-obtain-token" został uzyskany token przykładowego użytkownika o nazwie "Bob":
![1-obtain token](https://github.com/user-attachments/assets/069efb9c-6877-45b4-b12f-a5e1736a86db)

Treść owego tokena: `"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhY2NvdW50IjoiQm9iIiwicm9sZSI6IlVzZXIiLCJpYXQiOjE3MzM5MzY3MTYsImF1ZCI6Imh0dHBzOi8vMTI3LjAuMC4xL2p3dC9ub25lIn0.2saKf6BbPBA7WdAaDMfw_j7EsiHLR47s425lAW5OjCM"`

Po zdekodowaniu częsci tokenu przy użyciu Base64 uzyskujemy więcej danych o użytkowniku i samym tokenie: `"{"alg":"HS256","typ":"JWT"}{"account":"Bob","role":"User","iat":1733936716,"aud":"https://127.0.0.1/jwt/none"}"`

### Atak

Aby przeprowadzić atak wystarczy wpisać wybrany algorytm jako "none" oraz usunąć sygnaturę tokenu (na końcu zostawiamy znak '.') pozwala nam to na dostęp do konta "Administrator".

Zmodyfikowana treść tokena: `"{"alg":"none","typ":"JWT"}{"account":"Administrator","role":"User","iat":1733936716,"aud":"https://127.0.0.1/jwt/none"}"`
Zmodyfikowany token: `"eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.eyJhY2NvdW50IjoiQWRtaW5pc3RyYXRvciIsInJvbGUiOiJVc2VyIiwiaWF0IjoxNzMzOTM2NzE2LCJhdWQiOiJodHRwczovLzEyNy4wLjAuMS9qd3Qvbm9uZSJ9."`

Wynik skutecznie przeprowadzonego ataku:
![2-attack successful](https://github.com/user-attachments/assets/0f7f759a-6b40-43c7-bc8a-0748cf06b545)

### Propozycja poprawki

Proponuję usunąć możliwość akceptacji algorytmu "none" co powoduje, że są akceptowane tylko tokeny JWT z właściwą sygnaturą.

Przykład działania po zaimplementowaniu poprawki:
![3-po poprawce](https://github.com/user-attachments/assets/acd9cd13-1173-49a1-a43e-a8ef3b7457c0)