### PR TITLE
Fix: Naprawa podatności JWT, testy, Lab 3

### DIFF
--- a/JWT/jwt-signature-apis-challenges/app.js
+++ b/JWT/jwt-signature-apis-challenges/app.js
@@ -31,7 +31,7 @@ app.post('/jwt/none', (req, res) => { //None endpoint
     } else if (jwt_b64_dec.header.alg == 'none') {
       secret_key = '';
     }
-    JWT.verify(jwt_token, secret_key, { algorithms: ['none', 'HS256'], complete: true, audience: 'https://127.0.0.1/jwt/none' }, (err, decoded_token) => {
+    JWT.verify(jwt_token, secret_key, { algorithms: ['HS256'], complete: true, audience: 'https://127.0.0.1/jwt/none' }, (err, decoded_token) => {
       if (err) {
         res.status(400).json(err);
       } else {

--- a/Python/Flask_Book_Library/Dockerfile
+++ b/Python/Flask_Book_Library/Dockerfile
@@ -10,6 +10,8 @@ ENV FLASK_ENV=development
 ENV PASSWORD=1qaz@WSX
 # Instalujemy zależności
 RUN pip install --no-cache-dir -r requirements.txt
+# Testy
+RUN pip install pytest; pytest -xv
 
 # Ustawiamy zmienną środowiskową, aby Flask wiedział, jak uruchomić aplikację
 ENV FLASK_APP=app.py

--- a/Python/Flask_Book_Library/pytest.ini
+++ b/Python/Flask_Book_Library/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = .

--- a/Python/Flask_Book_Library/test/test_book_model.py
+++ b/Python/Flask_Book_Library/test/test_book_model.py
@@ -1,0 +1,274 @@
+import datetime
+
+import pytest
+
+from project import app, db
+from project.books.models import Book
+
+
+@pytest.fixture
+def test_db():
+    app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+    with app.app_context():
+        db.create_all()
+        yield db
+        db.session.remove()
+        db.drop_all()
+
+injections = [
+    "';DROP TABLE books; --'",
+    "<script>alert(\"xss\")</script>",
+    "10; system('yes')",
+    "| yes"
+]
+
+@pytest.mark.parametrize(
+    ("name", "author", "year_published", "book_type", "status"),
+    [
+        ("Lalka", "Bolesław Prus", 1890, "2days", "available"),
+        ("Solaris", "Stanisław Lem", 1961, "5days", "available"),
+        ("Przedwiośnie", "Stefan Żeromski", 1924, "10days", "available")
+    ]
+)
+def test_book_good(test_db, name, author, year_published, book_type, status):
+    book = Book(name, author, year_published, book_type, status)
+    test_db.session.add(book)
+    test_db.session.commit()
+
+    saved_book = Book.query.filter_by(name=name).first()
+    assert saved_book.name == book.name
+    assert saved_book.author == book.author
+    assert saved_book.year_published == book.year_published
+    assert saved_book.book_type == book.book_type
+    assert saved_book.status == book.status
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "a" * 1000,
+        "a" * 10000,
+        "a" * 100000,
+        "",
+        "a\nb\nc"
+    ]
+)
+def test_book_name_invalid(test_db, name):
+    book = Book(name, "author", "1234", "2days")
+    # unreasonably long (or empty) names should not be allowed, single line
+    with pytest.raises(Exception):
+        test_db.session.add(book)
+        test_db.session.commit()
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        1000,
+        10.0,
+        None,
+        {},
+        []
+    ]
+)
+def test_book_name_incorrect_type(test_db, name):
+    book = Book(name, "author", "1234", "2days")
+    # should be str
+    with pytest.raises(Exception):
+        test_db.session.add(book)
+        test_db.session.commit()
+
+
+@pytest.mark.parametrize(
+    "name", injections
+)
+def test_book_name_injections(test_db, name):
+    book = Book(name, "author", "1234", "2days")
+    # should not be saved in the db
+    with pytest.raises(Exception):
+        test_db.session.add(book)
+        test_db.session.commit()
+
+
+@pytest.mark.parametrize(
+    "author",
+    [
+        "a" * 1000,
+        "a" * 10000,
+        "a" * 100000,
+        "",
+        "a\nb\nc"
+    ]
+)
+def test_book_author_invalid(test_db, author):
+    book = Book("name", author, "1234", "2days")
+    # unreasonably long (or empty) authors should not be allowed, single line
+    with pytest.raises(Exception):
+        test_db.session.add(book)
+        test_db.session.commit()
+
+
+@pytest.mark.parametrize(
+    "author",
+    [
+        1000,
+        10.0,
+        None,
+        {},
+        []
+    ]
+)
+def test_book_author_incorrect_type(test_db, author):
+    book = Book("name", author, "1234", "2days")
+    # should be str
+    with pytest.raises(Exception):
+        test_db.session.add(book)
+        test_db.session.commit()
+
+
+@pytest.mark.parametrize(
+    "author", injections
+)
+def test_book_author_injections(test_db, author):
+    book = Book("name", author, "1234", "2days")
+    # should be str
+    with pytest.raises(Exception):
+        test_db.session.add(book)
+        test_db.session.commit()
+
+
+@pytest.mark.parametrize(
+    "year",
+    [
+        datetime.datetime.today().year + 1,
+        2**32-1,
+        -10**9
+    ]
+)
+def test_book_year_invalid(test_db, year):
+    book = Book("name", "author", year, "2days")
+    # unreasonably long authors should not be allowed
+    with pytest.raises(Exception):
+        test_db.session.add(book)
+        test_db.session.commit()
+
+
+@pytest.mark.parametrize(
+    "year",
+    [
+        "a" * 10000,
+        34.2,
+        None,
+        {},
+        []
+    ]
+)
+def test_book_year_incorrect_type(test_db, year):
+    book = Book("name", "author", year, "2days")
+    # should be int
+    with pytest.raises(Exception):
+        test_db.session.add(book)
+        test_db.session.commit()
+
+
+@pytest.mark.parametrize(
+    "year", injections
+)
+def test_book_year_injections(test_db, year):
+    book = Book("name", "author", year, "2days")
+    # should be int
+    with pytest.raises(Exception):
+        test_db.session.add(book)
+        test_db.session.commit()
+
+
+@pytest.mark.parametrize(
+    "book_type",
+    [
+        "",
+        "3days",
+        "a" * 10000
+    ]
+)
+def test_book_book_type_invalid(test_db, book_type):
+    book = Book("name", "author", 2002, book_type)
+    # the only accepted values should be 2days, 5days, 10days per books/forms.py
+    with pytest.raises(Exception):
+        test_db.session.add(book)
+        test_db.session.commit()
+
+
+@pytest.mark.parametrize(
+    "book_type",
+    [
+        2002,
+        34.2,
+        None,
+        {},
+        []
+    ]
+)
+def test_book_book_type_incorrect_type(test_db, book_type):
+    book = Book("name", "author", 2002, book_type)
+    # should be str
+    with pytest.raises(Exception):
+        test_db.session.add(book)
+        test_db.session.commit()
+
+
+@pytest.mark.parametrize(
+    "book_type", injections
+)
+def test_book_book_type_injections(test_db, book_type):
+    book = Book("name", "author", 2002, book_type)
+    # should be str
+    with pytest.raises(Exception):
+        test_db.session.add(book)
+        test_db.session.commit()
+
+
+@pytest.mark.parametrize(
+    "status",
+    [
+        "unavailable",
+        "",
+        "a" * 10000
+    ]
+)
+def test_book_status_invalid(test_db, status):
+    book = Book("name", "author", 2002, "2days", status)
+    # the only valid status seems to be "available"?
+    with pytest.raises(Exception):
+        test_db.session.add(book)
+        test_db.session.commit()
+
+
+@pytest.mark.parametrize(
+    "status",
+    [
+        2002,
+        34.2,
+        None,
+        {},
+        []
+    ]
+)
+def test_book_status_incorrect_type(test_db, status):
+    book = Book("name", "author", 2002, "2days", status)
+    # should be str
+    with pytest.raises(Exception):
+        test_db.session.add(book)
+        test_db.session.commit()
+
+
+@pytest.mark.parametrize(
+    "status", injections
+)
+def test_book_status_injections(test_db, status):
+    book = Book("name", "author", 2002, "2days", status)
+    # should be str
+    with pytest.raises(Exception):
+        test_db.session.add(book)
+        test_db.session.commit()
+
+


### PR DESCRIPTION
# 1. Testy

## Kod testów

Testy zostały umieszczone w pliku `test/test_book_model.py`. Zawarte w nim testy
- tworzą dla każdego testu nową bazę danych w pamięci
- sprawdzają poprawność zapisu poprawnych danych
- sprawdzają, czy próba zapisu danych ekstremalnych, przypadków brzegowych, danych o złym typie lub takich zawierających potencjalne exploity jest możliwa
Do testów została użyta biblioteka `pytest`.

## Dockerfile
W pliku `Dockerfile` po linii instalującej zależności projektu znalazła się linijka uruchamiająca testy. Aby niepotrzebne nie wydłużać czasu buildu, który zostanie przerwany przez niepowodzenie testów pytest wywoływany jest z flagą `-x` która przerywa testy po pierwszym niepowodzeniu.

# 2. JWT

## Wykorzystanie podatności

Wysyłając POST request do endpointu `/jwt` otrzymałem JWT
```
eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhY2NvdW50IjoiQm9iIiwicm9sZSI6IlVzZXIiLCJpYXQiOjE3NjQ1NDk4MDcsImF1ZCI6Imh0dHBzOi8vMTI3LjAuMC4xL2p3dC9ub25lIn0.QL5PL3l5mxfFpzObkZ9oHZwt39Uh1JNJjgs4beVn0Ok
```
który dekoduje się jako
```json
{
  "alg": "HS256",
  "typ": "JWT"
}
{
  "account": "Bob",
  "role": "User",
  "iat": 1764549807,
  "aud": "https://127.0.0.1/jwt/none"
}
```
z podpisem `a-string-secret-at-least-256-bits-long`

Zmieniając typ algorytmu na "none", konto na "administrator" oraz usuwając zupełnie sekcję zawierającą podpis uzyskałem JWT
```
eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.eyJhY2NvdW50IjoiYWRtaW5pc3RyYXRvciIsInJvbGUiOiJVc2VyIiwiaWF0IjoxNzY0NTQ5ODA3LCJhdWQiOiJodHRwczovLzEyNy4wLjAuMS9qd3Qvbm9uZSJ9.
```
które przesłane do endpointu `/jwt/none` skutkuje uzyskaniem odpowiedzi 
<img width="1848" height="913" alt="Pasted image 20251201020411" src="https://github.com/user-attachments/assets/ec11a1b7-107b-43ab-ba91-729974eac507" />



## Naprawa podatności

W pliku `app.js` w linii 34 lista `algorithms` została zmieniona:
```js
JWT.verify(jwt_token, secret_key, { algorithms: ['HS256'], complete: true, audience: 'https://127.0.0.1/jwt/none' }, (err, decoded_token) => {
```
Lista nie zawiera już pozycji "none" na liście dozwolonych algorytmów sprawdzania podpisu, uniemożliwiając uwierzytelnienie jako administrator poprzez prostą podmianę zawartości JWT.